### PR TITLE
WeightedSelector: Return nil when no elements available

### DIFF
--- a/lib/liquid/weighted_selector.rb
+++ b/lib/liquid/weighted_selector.rb
@@ -39,7 +39,7 @@ class WeightedSelector
   end
 
   def pick_one
-    pick_one_with_index[0]
+    pick_one_with_index[0] unless empty?
   end
 
 end

--- a/spec/lib/liquid/weighted_selector_spec.rb
+++ b/spec/lib/liquid/weighted_selector_spec.rb
@@ -27,6 +27,12 @@ describe WeightedSelector do
 
     context do
 
+      its(:pick_one){ should == nil }
+
+    end
+
+    context do
+
       before do
         subject.add 'a', 2
         subject.add 'b', 2


### PR DESCRIPTION
Previously, exception was raised in this condition:

```
TypeError:
   no implicit conversion from nil to integer
 # ./lib/liquid/weighted_selector.rb:38:in `pick_one_with_index'
```
