### PR TITLE
use new kafka producer api

### DIFF
--- a/lib/liquid/server.rb
+++ b/lib/liquid/server.rb
@@ -36,11 +36,17 @@ if RUBY_PLATFORM == "java"
 
       def initialize_tracker
         if $conf.tracker.kafka.enabled
-          # http://kafka.apache.org/documentation.html#producerconfigs
+          # http://kafka.apache.org/documentation.html#newproducerconfigs
           properties = java.util.Properties.new
-          properties['metadata.broker.list'] = $conf.tracker.kafka.brokers.join(',')
-          properties['producer.type'] = 'async'
-          properties['serializer.class'] = 'kafka.serializer.StringEncoder'
+          properties['bootstrap.servers'] = $conf.tracker.kafka.brokers.join(',')
+          properties['key.serializer'] = 'org.apache.kafka.common.serialization.StringSerializer'
+          properties['value.serializer'] = 'org.apache.kafka.common.serialization.StringSerializer'
+          properties['linger.ms'] = 10
+
+          if ['gzip', 'snappy'].include? $conf.tracker.kafka.compression
+            properties['compression.type'] = $conf.tracker.kafka.compression
+          end
+
           $tracker = ::Tracker::KafkaTracker.new(properties, $conf.tracker.dimensions)
         else
           $tracker = ::Tracker::LoggerTracker.new($conf.tracker.dimensions)

--- a/lib/liquid/tracker/kafka_tracker.rb
+++ b/lib/liquid/tracker/kafka_tracker.rb
@@ -3,13 +3,12 @@ require 'liquid/tracker/base'
 module Tracker
   class KafkaTracker < Base
 
-    java_import 'kafka.javaapi.producer.Producer'
-    java_import 'kafka.producer.ProducerConfig'
-    java_import 'kafka.producer.KeyedMessage'
+    java_import 'org.apache.kafka.clients.producer.KafkaProducer'
+    java_import 'org.apache.kafka.clients.producer.ProducerRecord'
 
     def initialize(properties, dimensions = {})
       super(dimensions)
-      @producer = Producer.new(ProducerConfig.new(properties))
+      @producer = KafkaProducer.new(properties)
     end
 
     def down?
@@ -19,7 +18,7 @@ module Tracker
     end
 
     def event(topic, data)
-      @producer.send(KeyedMessage.new(topic, data))
+      @producer.send(ProducerRecord.new(topic, data))
     rescue => e
       # TODO: maybe fall back to FileTracker here
       $log.exception(e, "failed to log #{topic}=#{data.inspect}")
@@ -27,8 +26,6 @@ module Tracker
 
     def shutdown
       @producer.close if @producer
-    rescue Java::KafkaProducer::ProducerClosedException
-      # pass
     end
 
   end


### PR DESCRIPTION
This is an attempt to see if the new producer api is any better. Also the new producer api allows for trivial selection of the target kafka partition which would be very nice for ensuring local writes only. (Read: future work)